### PR TITLE
PAYARA-3660: Drop bean defining annotation from Rest interface

### DIFF
--- a/rest-client/server-internal/src/main/java/org/eclipse/microprofile14/restclient/serverinternal/client/HelloService.java
+++ b/rest-client/server-internal/src/main/java/org/eclipse/microprofile14/restclient/serverinternal/client/HelloService.java
@@ -17,7 +17,6 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * @author Ondrej Mihalyi
  */
 @Path("/api/hello")
-@RequestScoped
 @RegisterRestClient  // Required to enable injection of this interface
 public interface HelloService {
 


### PR DESCRIPTION
Since Rest Client 1.1, the registration should work without additional
annotation